### PR TITLE
Fix tests and VS2022

### DIFF
--- a/Test/DeviceEnum/main.cpp
+++ b/Test/DeviceEnum/main.cpp
@@ -55,7 +55,7 @@ int main( int argc, char** argv )
 		ERROR_CHECK( e );
 
 		oroDeviceProp props;
-		e = oroGetDeviceProperties( &props, i );
+		e = oroGetDeviceProperties( &props, device );
 		ERROR_CHECK( e );
 		printf( "executing on %s (%s)\n", props.name, props.gcnArchName );
 

--- a/Test/VulkanComputeSimple/main.cpp
+++ b/Test/VulkanComputeSimple/main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 	oroCtx ctx;
 	e = oroCtxCreate(&ctx, 0, device);
 	oroDeviceProp props;
-	e = oroGetDeviceProperties(&props, 0);
+	e = oroGetDeviceProperties(&props, device);
 	try {
 		vk::raii::Context context;
 		vk::ApplicationInfo applicationInfo(AppName.c_str(), 1, EngineName.c_str(),

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv )
 	printf(">> testing device props\n");
 	{
 		oroDeviceProp props;
-		oroGetDeviceProperties( &props, 0 );
+		oroGetDeviceProperties( &props, device );
 		printf("executing on %s (%s)\n", props.name, props.gcnArchName );
 	}
 	printf(">> testing kernel execution\n");

--- a/premake5.lua
+++ b/premake5.lua
@@ -30,7 +30,7 @@ workspace "YamatanoOrochi"
    if os.istarget("windows") then
       buildoptions { "/wd4244", "/wd4305", "/wd4018", "/wd4244" }
    end
-   buildoptions{ "-Wno-ignored-attributes" }
+   -- buildoptions{ "-Wno-ignored-attributes" }
    startproject "Test"
 
    include "./Test"


### PR DESCRIPTION
This prevents tests from failing by passing device as an argument.

Also this PR enables building in VS2022 by commenting out a failure-introducing flag, I am not sure if that is regressive.

cc: @takahiroharada 