### PR TITLE
[ORO-0] Support newer HIP builds on windows

### DIFF
--- a/contrib/hipew/src/hipew.cpp
+++ b/contrib/hipew/src/hipew.cpp
@@ -61,8 +61,11 @@ typedef void* DynamicLibrary;
         _LIBRARY_FIND_CHECKED(hip_lib, name)
 #define HIP_LIBRARY_FIND(name) _LIBRARY_FIND(hip_lib, name)
 
+#define HIPRTC_LIBRARY_FIND_CHECKED( name ) _LIBRARY_FIND_CHECKED( hiprtc_lib, name )
+#define HIPRTC_LIBRARY_FIND( name ) _LIBRARY_FIND( hiprtc_lib, name )
 
 static DynamicLibrary hip_lib;
+static DynamicLibrary hiprtc_lib;
 
 /* Function definitions. */
 thipGetErrorName *hipGetErrorName;
@@ -259,13 +262,15 @@ static int hipewHasOldDriver(const char *hip_path) {
 static int hipewHipInit(void) {
   /* Library paths. */
 #ifdef _WIN32
-  /* Expected in c:/windows/system or similar, no path needed. */
-  const char *hip_paths[] = {"amdhip64.dll", NULL};
+  /* Expected in C:/Windows/System32 or similar, no path needed. */
+  const char* hip_paths[] = {"amdhip64.dll", NULL};
+  const char *hiprtc_paths[] = {"hiprtc.dll", NULL};
 #elif defined(__APPLE__)
   /* Default installation path. */
   const char *hip_paths[] = {"", NULL};
 #else
   const char *hip_paths[] = {"/opt/rocm/hip/lib/libamdhip64.so", NULL};
+  const char* hiprtc_paths[] = { "", NULL };
 #endif
   static int initialized = 0;
   static int result = 0;
@@ -293,6 +298,7 @@ static int hipewHipInit(void) {
 
   /* Load library. */
   hip_lib = dynamic_library_open_find(hip_paths);
+  hiprtc_lib = dynamic_library_open_find(hiprtc_paths);
 
   if (hip_lib == NULL) {
     result = HIPEW_ERROR_OPEN_FAILED;
@@ -423,16 +429,32 @@ static int hipewHipInit(void) {
   HIP_LIBRARY_FIND_CHECKED(hipImportExternalMemory);
   HIP_LIBRARY_FIND_CHECKED(hipExternalMemoryGetMappedBuffer);
   HIP_LIBRARY_FIND_CHECKED(hipDestroyExternalMemory);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetErrorString);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcAddNameExpression);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcCompileProgram);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcCreateProgram);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcDestroyProgram);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetLoweredName);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetProgramLog);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetProgramLogSize);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetCode);
-  HIP_LIBRARY_FIND_CHECKED(hiprtcGetCodeSize);
+  if(hiprtc_lib)
+  {
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetErrorString);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcAddNameExpression);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcCompileProgram);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcCreateProgram);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcDestroyProgram);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetLoweredName);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetProgramLog);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetProgramLogSize);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetCode);
+      HIPRTC_LIBRARY_FIND_CHECKED(hiprtcGetCodeSize);
+  }
+  else
+  {
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetErrorString);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcAddNameExpression);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcCompileProgram);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcCreateProgram);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcDestroyProgram);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetLoweredName);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetProgramLog);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetProgramLogSize);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetCode);
+      HIP_LIBRARY_FIND_CHECKED(hiprtcGetCodeSize);
+  }
   result = HIPEW_SUCCESS;
   return result;
 }


### PR DESCRIPTION
Newer HIP builds split hiprtc into a separate DLL, which is covered by this PR for future-proofing.