### PR TITLE
Fix oroCtxGetCurrent api for ADL

### DIFF
--- a/Orochi/Orochi.cpp
+++ b/Orochi/Orochi.cpp
@@ -195,8 +195,8 @@ orortcResult nvrtc2oro( nvrtcResult a )
 #define __ORO_CTXT_FUNC( name ) __ORO_FUNC1(Ctx##name, name)
 #define __ORO_CTXT_FUNCX( API, name ) __ORO_FUNC1X(API, Ctx##name, name)
 //#define __ORO_CTXT_FUNC( name ) if( s_api == ORO_API_CUDA ) return cu2oro( cuCtx##name ); if( s_api == ORO_API_HIP ) return hip2oro( hip##name );
-#define __ORORTC_FUNC1( cuname, hipname ) if( API & ORO_API_CUDADRIVER ) return nvrtc2oro( nvrtc##cuname ); if( s_api == ORO_API_HIP ) return hiprtc2oro( hiprtc##hipname );
-#define __ORO_RET_ERR( e ) if( API & ORO_API_CUDADRIVER ) return cu2oro((CUresult)e ); if( s_api == ORO_API_HIP ) return hip2oro( (hipError_t)e );
+#define __ORORTC_FUNC1( cuname, hipname ) if( s_api & ORO_API_CUDADRIVER ) return nvrtc2oro( nvrtc##cuname ); if( s_api == ORO_API_HIP ) return hiprtc2oro( hiprtc##hipname );
+#define __ORO_RET_ERR( e ) if( s_api & ORO_API_CUDADRIVER ) return cu2oro((CUresult)e ); if( s_api == ORO_API_HIP ) return hip2oro( (hipError_t)e );
 
 
 oroError OROAPI oroGetErrorName(oroError error, const char** pStr)
@@ -385,7 +385,7 @@ oroError OROAPI oroCtxCreate(oroCtx* pctx, unsigned int flags, oroDevice dev)
 	(*pctx) = ctxt;
 	s_api = ctxt->getApi();
 	int e = oroErrorUnknown;
-	if( API & ORO_API_CUDADRIVER ) e = cuCtxCreate( oroCtx2cu( pctx ), flags, d.getDevice() );
+	if( s_api & ORO_API_CUDADRIVER ) e = cuCtxCreate( oroCtx2cu( pctx ), flags, d.getDevice() );
 	if( s_api == ORO_API_HIP ) e = hipCtxCreate( oroCtx2hip( pctx ), flags, d.getDevice() );
 	if( e )
 	{
@@ -427,7 +427,7 @@ oroError OROAPI oroCtxGetCurrent(oroCtx* pctx)
 {
 	ioroCtx_t* ctxt = new ioroCtx_t;
 	int e = oroErrorUnknown;
-	if( API & ORO_API_CUDADRIVER ) e = cuCtxGetCurrent( oroCtx2cu( &ctxt ) );
+	if( s_api & ORO_API_CUDADRIVER ) e = cuCtxGetCurrent( oroCtx2cu( &ctxt ) );
 	if( s_api == ORO_API_HIP ) e = hipCtxGetCurrent( oroCtx2hip( &ctxt ) );
 	if( e )
 	{

--- a/Orochi/Orochi.cpp
+++ b/Orochi/Orochi.cpp
@@ -408,11 +408,9 @@ oroError OROAPI oroCtxSetCurrent(oroCtx ctx)
 	return oroErrorUnknown;
 }
 
-oroError OROAPI oroCtxGetCurrent(oroCtx* pctx)
+oroError OROAPI oroCtxGetCurrent(void* pctx )
 {
-    ioroCtx_t ctxt;
-    ( *pctx ) = &ctxt;
-	__ORO_FUNC1( CtxGetCurrent( oroCtx2cu(pctx) ), CtxGetCurrent( oroCtx2hip(pctx) ) );
+	__ORO_FUNC1( CtxGetCurrent( (CUcontext*)pctx ), CtxGetCurrent( (hipCtx_t*)pctx ) );
 	return oroErrorUnknown;
 }
 /*

--- a/Orochi/Orochi.cpp
+++ b/Orochi/Orochi.cpp
@@ -25,8 +25,11 @@
 #include <contrib/hipew/include/hipew.h>
 #include <stdio.h>
 #include <string.h>
+#include <unordered_map>
+#include <mutex>
 
-
+std::unordered_map<void*, oroCtx> s_oroCtxs;
+static std::mutex mtx;
 thread_local static oroApi s_api = ORO_API_HIP;
 static oroU32 s_loadedApis = 0;
 
@@ -192,7 +195,8 @@ orortcResult nvrtc2oro( nvrtcResult a )
 #define __ORO_CTXT_FUNC( name ) __ORO_FUNC1(Ctx##name, name)
 #define __ORO_CTXT_FUNCX( API, name ) __ORO_FUNC1X(API, Ctx##name, name)
 //#define __ORO_CTXT_FUNC( name ) if( s_api == ORO_API_CUDA ) return cu2oro( cuCtx##name ); if( s_api == ORO_API_HIP ) return hip2oro( hip##name );
-#define __ORORTC_FUNC1( cuname, hipname ) if( s_api & ORO_API_CUDADRIVER ) return nvrtc2oro( nvrtc##cuname ); if( s_api == ORO_API_HIP ) return hiprtc2oro( hiprtc##hipname );
+#define __ORORTC_FUNC1( cuname, hipname ) if( API & ORO_API_CUDADRIVER ) return nvrtc2oro( nvrtc##cuname ); if( s_api == ORO_API_HIP ) return hiprtc2oro( hiprtc##hipname );
+#define __ORO_RET_ERR( e ) if( API & ORO_API_CUDADRIVER ) return cu2oro((CUresult)e ); if( s_api == ORO_API_HIP ) return hip2oro( (hipError_t)e );
 
 
 oroError OROAPI oroGetErrorName(oroError error, const char** pStr)
@@ -380,12 +384,23 @@ oroError OROAPI oroCtxCreate(oroCtx* pctx, unsigned int flags, oroDevice dev)
 	ctxt->setApi( d.getApi() );
 	(*pctx) = ctxt;
 	s_api = ctxt->getApi();
-	__ORO_FUNC1X( d.getApi(), CtxCreate( oroCtx2cu( pctx ), flags, d.getDevice() ), CtxCreate( oroCtx2hip( pctx ), flags, d.getDevice() ) );
-	return oroErrorUnknown;
+	int e = oroErrorUnknown;
+	if( API & ORO_API_CUDADRIVER ) e = cuCtxCreate( oroCtx2cu( pctx ), flags, d.getDevice() );
+	if( s_api == ORO_API_HIP ) e = hipCtxCreate( oroCtx2hip( pctx ), flags, d.getDevice() );
+	if( e )
+	{
+		__ORO_RET_ERR( e )
+	}
+	std::lock_guard<std::mutex> lock( mtx );
+	s_oroCtxs[ctxt->m_ptr] = ctxt;
+	return oroSuccess;
 }
 
 oroError OROAPI oroCtxDestroy(oroCtx ctx)
 {
+	std::lock_guard<std::mutex> lock( mtx );
+	s_oroCtxs.erase( ctx->m_ptr );
+
 	int e = 0;
 	if( s_api & ORO_API_CUDADRIVER ) e = cuCtxDestroy( *oroCtx2cu( &ctx ) );
 	if( s_api == ORO_API_HIP ) e = hipCtxDestroy( *oroCtx2hip( &ctx ) );
@@ -408,10 +423,21 @@ oroError OROAPI oroCtxSetCurrent(oroCtx ctx)
 	return oroErrorUnknown;
 }
 
-oroError OROAPI oroCtxGetCurrent(void* pctx )
+oroError OROAPI oroCtxGetCurrent(oroCtx* pctx)
 {
-	__ORO_FUNC1( CtxGetCurrent( (CUcontext*)pctx ), CtxGetCurrent( (hipCtx_t*)pctx ) );
-	return oroErrorUnknown;
+	ioroCtx_t* ctxt = new ioroCtx_t;
+	int e = oroErrorUnknown;
+	if( API & ORO_API_CUDADRIVER ) e = cuCtxGetCurrent( oroCtx2cu( &ctxt ) );
+	if( s_api == ORO_API_HIP ) e = hipCtxGetCurrent( oroCtx2hip( &ctxt ) );
+	if( e )
+	{
+		__ORO_RET_ERR( e )
+	}
+
+	( *pctx ) = s_oroCtxs[ctxt->m_ptr];
+
+	delete ctxt;
+	return oroSuccess;
 }
 /*
 oroError OROAPI oroCtxGetDevice(oroDevice* device);

--- a/Orochi/Orochi.cpp
+++ b/Orochi/Orochi.cpp
@@ -410,6 +410,8 @@ oroError OROAPI oroCtxSetCurrent(oroCtx ctx)
 
 oroError OROAPI oroCtxGetCurrent(oroCtx* pctx)
 {
+    ioroCtx_t ctxt;
+    ( *pctx ) = &ctxt;
 	__ORO_FUNC1( CtxGetCurrent( oroCtx2cu(pctx) ), CtxGetCurrent( oroCtx2hip(pctx) ) );
 	return oroErrorUnknown;
 }

--- a/Orochi/Orochi.h
+++ b/Orochi/Orochi.h
@@ -612,7 +612,7 @@ oroError OROAPI oroCtxDestroy(oroCtx ctx) ;
 oroError OROAPI oroCtxPushCurrent(oroCtx ctx) ;
 oroError OROAPI oroCtxPopCurrent(oroCtx* pctx) ;
 oroError OROAPI oroCtxSetCurrent(oroCtx ctx) ;
-oroError OROAPI oroCtxGetCurrent(oroCtx* pctx) ;
+oroError OROAPI oroCtxGetCurrent(void* pctx) ;
 oroError OROAPI oroCtxGetDevice(oroDevice* device) ;
 oroError OROAPI oroCtxGetFlags(unsigned int* flags) ;
 oroError OROAPI oroCtxSynchronize(void) ;

--- a/Orochi/Orochi.h
+++ b/Orochi/Orochi.h
@@ -612,7 +612,7 @@ oroError OROAPI oroCtxDestroy(oroCtx ctx) ;
 oroError OROAPI oroCtxPushCurrent(oroCtx ctx) ;
 oroError OROAPI oroCtxPopCurrent(oroCtx* pctx) ;
 oroError OROAPI oroCtxSetCurrent(oroCtx ctx) ;
-oroError OROAPI oroCtxGetCurrent(void* pctx) ;
+oroError OROAPI oroCtxGetCurrent(oroCtx* pctx) ;
 oroError OROAPI oroCtxGetDevice(oroDevice* device) ;
 oroError OROAPI oroCtxGetFlags(unsigned int* flags) ;
 oroError OROAPI oroCtxSynchronize(void) ;


### PR DESCRIPTION
This fix helps to get the correct context from the isValid() ADL API. Otherwise, this function throws an exception.