### PR TITLE
[ORO-0] Update scripts for linux

### DIFF
--- a/scripts/unittest.sh
+++ b/scripts/unittest.sh
@@ -1,1 +1,2 @@
+cd ../UnitTest/bitcodes && ./generate_bitcodes.sh && cd ../../scripts
 ../dist/bin/Release/Unittest64 --gtest_filter=-*link*:*getErrorString* --gtest_output=xml:../result.xml

--- a/scripts/unittest_navi1.sh
+++ b/scripts/unittest_navi1.sh
@@ -1,1 +1,2 @@
+cd ../UnitTest/bitcodes && ./generate_bitcodes.sh && cd ../../scripts
 ../dist/bin/Release/Unittest64 --gtest_filter=-*link*:*getErrorString* --gtest_output=xml:../result.xml

--- a/scripts/unittest_navi2.sh
+++ b/scripts/unittest_navi2.sh
@@ -1,1 +1,2 @@
+cd ../UnitTest/bitcodes && ./generate_bitcodes.sh && cd ../../scripts
 ../dist/bin/Release/Unittest64 --gtest_filter=-*link*:*getErrorString* --gtest_output=xml:../result.xml

--- a/scripts/unittest_vega10.sh
+++ b/scripts/unittest_vega10.sh
@@ -1,1 +1,2 @@
+cd ../UnitTest/bitcodes && ./generate_bitcodes.sh && cd ../../scripts
 ../dist/bin/Release/Unittest64 --gtest_filter=-*link*:*getErrorString* --gtest_output=xml:../result.xml

--- a/scripts/unittest_vega20.sh
+++ b/scripts/unittest_vega20.sh
@@ -1,1 +1,2 @@
+cd ../UnitTest/bitcodes && ./generate_bitcodes.sh && cd ../../scripts
 ../dist/bin/Release/Unittest64 --gtest_filter=-*link*:*getErrorString* --gtest_output=xml:../result.xml


### PR DESCRIPTION
Because bitcodes need to be recompiled separately for windows and linux (the ones in the bitcodes folder are compiled from windows)