### PR TITLE
Fix Unit Test: getErrorString

### DIFF
--- a/UnitTest/main.cpp
+++ b/UnitTest/main.cpp
@@ -627,18 +627,27 @@ TEST_F( OroTestBase, link_bundledBc_with_bc_loweredName )
 
 TEST_F( OroTestBase, getErrorString )
 {
-	oroError error = (oroError)1;
-	const char *str = nullptr;
+	oroError error = oroError::oroErrorInvalidValue;
+	const char* str = nullptr;
 	OROCHECK( oroGetErrorString( error, &str ) );
-	oroApi api = oroGetCurAPI( 0 );
-	if(api == ORO_API_CUDADRIVER)
+	const oroApi api = oroGetCurAPI( 0 );
+	if( api == ORO_API_CUDADRIVER )
+	{
 		OROASSERT( str != nullptr );
+	}
 	else if( api == ORO_API_HIP )
-		OROASSERT( !strcmp(str, "invalid argument") );
+	{
+		constexpr auto hipErrorMessage{ "hipErrorInvalidValue" };
+		OROASSERT( std::string( str ) == hipErrorMessage );
+	}
+	else
+	{
+		// Unsupported api. This should not happen.
+		OROASSERT( false );
+	}
 }
 
-
-int main( int argc, char* argv[] ) 
+int main( int argc, char* argv[] )
 {
 	::testing::InitGoogleTest( &argc, argv );
 	return RUN_ALL_TESTS();


### PR DESCRIPTION
Fix Unit Test: getErrorString

Error:

```
[ RUN      ] OroTestBase.getErrorString
D:\Dev\Orochi-KaoCC\UnitTest\main.cpp(637): error: Value of: !strcmp(str, "invalid argument")
  Actual: false
Expected: true
[  FAILED  ] OroTestBase.getErrorString (0 ms)
```