### PR TITLE
Add libamdhip64.so search path by the standard way (man dlopen) as a fallback

### DIFF
--- a/contrib/hipew/src/hipew.cpp
+++ b/contrib/hipew/src/hipew.cpp
@@ -293,9 +293,11 @@ void hipewInit( int* resultDriver, int* resultRtc, hipuint32_t flags )
   const char* hiprtc_paths[] = { NULL };
 #else
   const char *hip_paths[] = { "/opt/rocm/hip/lib/libamdhip64.so",
-                              "/opt/rocm/lib/libamdhip64.so", NULL };
+                              "/opt/rocm/lib/libamdhip64.so",
+	                      "libamdhip64.so", NULL };
   const char* hiprtc_paths[] = { "/opt/rocm/hip/lib/libhiprtc.so",
-                              "/opt/rocm/lib/libhiprtc.so", NULL };
+                              "/opt/rocm/lib/libhiprtc.so", 
+	                      "libamdhip64.so", NULL };
 #endif
   static int initialized = 0;
   static int s_resultDriver = 0;


### PR DESCRIPTION
Some distributions of Linux do not install the hip library in the default path of `/opt/rocm/...`, but instead use the standard path like `/usr/lib(64)/...`, `/lib(64)`. Therefore, we should add a standard way (path without a slash) to locate the library.