### PR TITLE
update DLLs to 6.1.2

### DIFF
--- a/contrib/bin/win64/amd_comgr0601.dll
+++ b/contrib/bin/win64/amd_comgr0601.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e6b58a3484af4b2104fbe8bc1030e9c04f897b82bb1e41976aee511b379cf9c
-size 110272952
+oid sha256:d99d86fe78b719ca2f0502da3f37f5d41ef3f9efa0bc5ebf39c129cc31a9653d
+size 110273240

--- a/contrib/bin/win64/hiprtc-builtins0601.dll
+++ b/contrib/bin/win64/hiprtc-builtins0601.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2797ba9fa817f9a8f2cb3caa0f6dcdffdcb3b4c3dd353258536f7ac1522e727
-size 1065400
+oid sha256:cc29cf387cf1e1b59826f4ffe21922f849f47378cea3ec2ce00dc2ad38254d95
+size 1065688

--- a/contrib/bin/win64/hiprtc0601.dll
+++ b/contrib/bin/win64/hiprtc0601.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:893446666ddd9c076b24affc34d48b06332b212ec04ff42d568d25da2b168610
-size 1939896
+oid sha256:4ac7b741cf60afc4de24a07f15c3bd2fce5e052e0be8497960b75004a6d2de11
+size 1940184


### PR DESCRIPTION
using DLLs from:
https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html