### PR TITLE
update win bins from 6.2.4

### DIFF
--- a/contrib/bin/win64/amd_comgr0601.dll
+++ b/contrib/bin/win64/amd_comgr0601.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d99d86fe78b719ca2f0502da3f37f5d41ef3f9efa0bc5ebf39c129cc31a9653d
-size 110273240

--- a/contrib/bin/win64/amd_comgr0602.dll
+++ b/contrib/bin/win64/amd_comgr0602.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b276e38c1559ffd5dfc4530d7df435cfff5359e244302a7f405055f712d019ad
+size 111863504

--- a/contrib/bin/win64/hiprtc-builtins0601.dll
+++ b/contrib/bin/win64/hiprtc-builtins0601.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc29cf387cf1e1b59826f4ffe21922f849f47378cea3ec2ce00dc2ad38254d95
-size 1065688

--- a/contrib/bin/win64/hiprtc-builtins0602.dll
+++ b/contrib/bin/win64/hiprtc-builtins0602.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c02d0931af164748df880abd82e392a47c324842ebd0f5ce71d3f4b0bc0932ec
+size 1078480

--- a/contrib/bin/win64/hiprtc0601.dll
+++ b/contrib/bin/win64/hiprtc0601.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ac7b741cf60afc4de24a07f15c3bd2fce5e052e0be8497960b75004a6d2de11
-size 1940184

--- a/contrib/bin/win64/hiprtc0602.dll
+++ b/contrib/bin/win64/hiprtc0602.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f59ad2ee8a6467a9a717da2232d73e0341acec1620fed2e4e6d28df2f9877112
+size 1971920


### PR DESCRIPTION
DLLs from the installer of:
https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html