### PR TITLE
[ORO-0] Skip checkCUEW from regular test.

### DIFF
--- a/scripts/unittest.bat
+++ b/scripts/unittest.bat
@@ -1,2 +1,2 @@
 rd /s /q cache
-..\dist\bin\Release\Unittest64.exe --gtest_filter=-*link_bundledBc*:*VulkanComputeSimple64* --gtest_output=xml:../result.xml
+..\dist\bin\Release\Unittest64.exe --gtest_filter=-*checkCUEW*:*link_bundledBc*:*VulkanComputeSimple64* --gtest_output=xml:../result.xml

--- a/scripts/unittest.sh
+++ b/scripts/unittest.sh
@@ -2,4 +2,4 @@ rm -rf cache
 cd ../UnitTest/bitcodes
 ./generate_bitcodes.sh
 cd ../../scripts
-../dist/bin/Release/Unittest64 --gtest_filter=-*link_bundledBc* --gtest_output=xml:../result.xml
+../dist/bin/Release/Unittest64 --gtest_filter=-*checkCUEW*:*link_bundledBc* --gtest_output=xml:../result.xml


### PR DESCRIPTION
Can we exclude this test from the regular run? It keeps causing false failures in QA.