### PR TITLE
[ORO-0] Support ROCm 10

### DIFF
--- a/contrib/hipew/src/hipew.cpp
+++ b/contrib/hipew/src/hipew.cpp
@@ -665,11 +665,14 @@ void hipewInit( int* resultDriver, int* resultRtc, uint32_t flags, const char** 
   const char* hiprtc_paths[] = { NULL };
 #else
   const char *hip_paths[] = {
-
       // Each release is installed in its own '/opt/rocm/core-<MAJOR>.<MINOR>' directory,
-      "/opt/rocm/core-8.1/lib/libamdhip64.so.8",
-      "/opt/rocm/core-8.0/lib/libamdhip64.so.8",
-      "/opt/rocm/core-8/lib/libamdhip64.so.8",
+      "/opt/rocm/core-10.1/lib/libamdhip64.so.8",
+      "/opt/rocm/core-10.0/lib/libamdhip64.so.8",
+      "/opt/rocm/core-10/lib/libamdhip64.so.8",
+
+      "/opt/rocm/core-10.1/lib/libamdhip64.so.7",
+      "/opt/rocm/core-10.0/lib/libamdhip64.so.7",
+      "/opt/rocm/core-10/lib/libamdhip64.so.7",
 
       "/opt/rocm/core-7.16/lib/libamdhip64.so.7",
       "/opt/rocm/core-7.15/lib/libamdhip64.so.7",
@@ -704,9 +707,13 @@ void hipewInit( int* resultDriver, int* resultRtc, uint32_t flags, const char** 
   const char* hiprtc_paths[] = {
 
       // See the comment about the 'core-*' directories in 'hip_paths'.
-      "/opt/rocm/core-8.1/lib/libhiprtc.so.8",
-      "/opt/rocm/core-8.0/lib/libhiprtc.so.8",
-      "/opt/rocm/core-8/lib/libhiprtc.so.8",
+      "/opt/rocm/core-10.1/lib/libhiprtc.so.8",
+      "/opt/rocm/core-10.0/lib/libhiprtc.so.8",
+      "/opt/rocm/core-10/lib/libhiprtc.so.8",
+
+      "/opt/rocm/core-10.1/lib/libhiprtc.so.7",
+      "/opt/rocm/core-10.0/lib/libhiprtc.so.7",
+      "/opt/rocm/core-10/lib/libhiprtc.so.7",
 
       "/opt/rocm/core-7.16/lib/libhiprtc.so.7",
       "/opt/rocm/core-7.15/lib/libhiprtc.so.7",


### PR DESCRIPTION
## Summary
- Add ROCm 10 (`core-10`, `core-10.0`, `core-10.1`) search paths for `libamdhip64.so` and `libhiprtc.so` in `hipewInit`, covering both the `.so.8` and `.so.7` SONAMEs.

## Test plan
- [ ] Build and run on a system with ROCm 10 installed to confirm the HIP runtime is located correctly.